### PR TITLE
Additional property for ATA Device

### DIFF
--- a/pymelcloud/ata_device.py
+++ b/pymelcloud/ata_device.py
@@ -166,6 +166,8 @@ class AtaDevice(Device):
     @property
     def has_energy_consumed_meter(self) -> bool:
         """Return True if the device has an energy consumption meter."""
+        if self._device_conf is None:
+            return False
         return self._device_conf.get("Device", {}).get("HasEnergyConsumedMeter", False)
 
     @property
@@ -182,6 +184,50 @@ class AtaDevice(Device):
         if reading is None:
             return None
         return reading / 1000.0
+
+    @property
+    def wifi_signal(self) -> Optional[int]:
+        """Return wifi signal in dBm (negative value)."""
+        if self._device_conf is None:
+            return None
+        device = self._device_conf.get("Device", {})
+        reading = device.get("WifiSignalStrength", None)
+        if reading is None:
+            return None
+        return reading
+
+    @property
+    def has_error(self) -> bool:
+        """Return True if the device has error state."""
+        if self._device_conf is None:
+            return False
+        return self._device_conf.get("Device", {}).get("HasError", False)
+
+    @property
+    def error_code(self) -> Optional[str]:
+        """Return error_code.
+
+        This is a property that probably should be checked if "has_error" = true
+        Till now I have a fixed code = 8000 and never have error on the units
+        """
+        if self._device_conf is None:
+            return None
+        device = self._device_conf.get("Device", {})
+        reading = device.get("ErrorCode", None)
+        if reading is None:
+            return None
+        return reading
+
+    @property
+    def presets(self) -> List[Dict[Any, Any]]:
+        """Return presets configuration (preset created using melcloud app)."""
+        retval = []
+        if self._device_conf is not None:
+            presets_conf = self._device_conf.get("Presets", {})
+            for p in presets_conf:
+                retval.append(p)
+
+        return retval
 
     @property
     def room_temperature(self) -> Optional[float]:
@@ -314,8 +360,21 @@ class AtaDevice(Device):
             H_VANE_POSITION_3,
             H_VANE_POSITION_4,
             H_VANE_POSITION_5,
-            H_VANE_POSITION_SPLIT,
         ]
+        
+        # My model do not have split function, and the 2 property below are set to false
+        # But at the moment I don't know the correct property for check split, so I leave this code commented
+        
+        #if device.get("HasWideVane", False):
+        #    positions.append(H_VANE_POSITION_SPLIT)
+
+        ####### Or #######
+
+        #if device.get("ModelIsAirCurtain", False):
+        #    positions.append(H_VANE_POSITION_SPLIT)
+
+        positions.append(H_VANE_POSITION_SPLIT)
+        
         if device.get("SwingFunction", False):
             positions.append(H_VANE_POSITION_SWING)
 

--- a/pymelcloud/client.py
+++ b/pymelcloud/client.py
@@ -48,7 +48,7 @@ def _headers(token: str) -> Dict[str, str]:
     }
 
 
-async def _do_login(_session: ClientSession, email: str, password: str, language: Optional[int] = 0, persist_login: Optional[bool] = True):
+async def _do_login(_session: ClientSession, email: str, password: str, language: int = 0, persist_login: bool = True):
     body = {
         "Email": email,
         "Password": password,
@@ -71,13 +71,11 @@ async def login(
     *,
     conf_update_interval: Optional[timedelta] = None,
     device_set_debounce: Optional[timedelta] = None,
-    language: Optional[str] = "EN",
-    persist_login: Optional[bool] = True,
+    language: str = "EN",
+    persist_login: bool = True,
 ):
     """Login using email and password."""
-    lang = 0
-    if language:
-        lang = LANGUAGES.get(language, 0)
+    lang = LANGUAGES.get(language, 0)
     
     if session:
         response = await _do_login(session, email, password, lang, persist_login)

--- a/pymelcloud/client.py
+++ b/pymelcloud/client.py
@@ -48,7 +48,7 @@ def _headers(token: str) -> Dict[str, str]:
     }
 
 
-async def _do_login(_session: ClientSession, email: str, password: str, language: int, persist_login: bool):
+async def _do_login(_session: ClientSession, email: str, password: str, language: Optional[int] = 0, persist_login: Optional[bool] = True):
     body = {
         "Email": email,
         "Password": password,

--- a/pymelcloud/client.py
+++ b/pymelcloud/client.py
@@ -6,6 +6,34 @@ from aiohttp import ClientSession
 
 BASE_URL = "https://app.melcloud.com/Mitsubishi.Wifi.Client"
 
+LANGUAGES = {
+    'EN' : 0,
+    'BG' : 1,
+    'CS' : 2,
+    'DA' : 3,
+    'DE' : 4,
+    'ET' : 5,
+    'ES' : 6,
+    'FR' : 7,
+    'HY' : 8,
+    'LV' : 9,
+    'LT' : 10,
+    'HU' : 11,
+    'NL' : 12,
+    'NO' : 13,
+    'PL' : 14,
+    'PT' : 15,
+    'RU' : 16,
+    'FI' : 17,
+    'SV' : 18,
+    'IT' : 19,
+    'UK' : 20,
+    'TR' : 21,
+    'EL' : 22,
+    'HR' : 23,
+    'RO' : 24,
+    'SL' : 25,
+}
 
 def _headers(token: str) -> Dict[str, str]:
     return {
@@ -20,13 +48,13 @@ def _headers(token: str) -> Dict[str, str]:
     }
 
 
-async def _do_login(_session: ClientSession, email: str, password: str):
+async def _do_login(_session: ClientSession, email: str, password: str, language: int, persist_login: bool):
     body = {
         "Email": email,
         "Password": password,
-        "Language": 0,
+        "Language": language,
         "AppVersion": "1.19.1.1",
-        "Persist": True,
+        "Persist": persist_login,
         "CaptchaResponse": None,
     }
 
@@ -43,13 +71,19 @@ async def login(
     *,
     conf_update_interval: Optional[timedelta] = None,
     device_set_debounce: Optional[timedelta] = None,
+    language: Optional[str] = "EN",
+    persist_login: Optional[bool] = True,
 ):
     """Login using email and password."""
+    lang = 0
+    if language:
+        lang = LANGUAGES.get(language, 0)
+    
     if session:
-        response = await _do_login(session, email, password)
+        response = await _do_login(session, email, password, lang, persist_login)
     else:
         async with ClientSession() as _session:
-            response = await _do_login(_session, email, password)
+            response = await _do_login(_session, email, password, lang, persist_login)
 
     return Client(
         response.get("LoginData").get("ContextKey"),


### PR DESCRIPTION
Added some properties readable from device configuration:
- wifi_signal
- has_error
- error_code
- presets

Also added a check in "vane_horizontal_positions" method for position "H_VANE_POSITION_SPLIT", but I leaved it commented for the moment because not really sure. Additional test should be done.

Finally I added "login language" and "persist login info" as optional parameters in client login method. 
I don't think language login conflict with Headers "Accept-Language" option, it doesn't for me. But loggin in with a language that is different from the one used in MELCloud app, cause also the App to change the language. Anyway this mod do not change current behavior of the library.